### PR TITLE
Replace double quote escapement

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -67,3 +67,7 @@ __recovery/
 
 # Boss dependency manager vendor folder https://github.com/HashLoad/boss
 modules/
+
+# Created by lazarus
+backup/
+lib/

--- a/rc2po.dpr
+++ b/rc2po.dpr
@@ -100,6 +100,7 @@ begin
           Line := Line.Replace(Defines.Names[I], Defines.ValueFromIndex[I], [rfReplaceAll]);
 
         RebuildFilter(Line);
+        Line := Line.Replace('""','\"');
         Result.Add(Line);
       end;
     end;


### PR DESCRIPTION
In .rc files double quote is escaped by duplication `""`, in .po files it's
escaped with a backslash `\"`.